### PR TITLE
[SO-106] feat: 플래너 페이지 완성 및 아이템별 전환 추가

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,11 +1,10 @@
 import { Box, Button, Grid } from "@mui/material";
 import React from "react";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { useDispatch } from "react-redux";
 import { PrevPage } from "../../store/viewSlice";
 import { useSelector } from "react-redux";
 import { RootState } from "../../store/store";
-import { Settings } from "@mui/icons-material";
+import { ArrowBackIos, Settings } from "@mui/icons-material";
 
 const Header = () => {
   const dispatch = useDispatch();
@@ -16,7 +15,7 @@ const Header = () => {
       <Grid className='h-10 items-center' container>
         <Grid item className='w-10 flex justify-center' xs={1}>
           <button onClick={() => dispatch(PrevPage())}>
-            <ArrowBackIcon />
+            <ArrowBackIos />
           </button>
         </Grid>
         <Grid item xs={10}>

--- a/src/components/Modules/CustomText.tsx
+++ b/src/components/Modules/CustomText.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 
 type Props = {
-  type: "Title-large" | "Title-base" | "Title" | "Description" | "Content";
+  type:
+    | "Title-large"
+    | "Title-base"
+    | "Title"
+    | "Description"
+    | "Content"
+    | "Content-small";
   text: string;
 };
 
@@ -23,6 +29,9 @@ const CustomText = (props: Props) => {
       break;
     case "Content":
       textClassName = "text-sm";
+      break;
+    case "Content-small":
+      textClassName = "text-xs";
       break;
   }
 

--- a/src/components/Pages/ItemPage/ItemPage.tsx
+++ b/src/components/Pages/ItemPage/ItemPage.tsx
@@ -19,6 +19,11 @@ const tagList = ["비즈", "펜던트", "귀걸이"];
 
 const ItemPage = (props: Props) => {
   const view = useSelector((state: RootState) => state.view.currentView);
+  const viewId = useSelector((state: RootState) => state.view.requestParam);
+  if (viewId) {
+    console.log(viewId);
+  }
+
   const defaultClassName = "flex flex-col gap-1";
 
   return (
@@ -38,7 +43,7 @@ const ItemPage = (props: Props) => {
         </div>
         <div className={defaultClassName}>
           <CustomText type='Title' text='일정 기록' />
-          <CustomText type='Content' text='2021.01.01 ~ 2021.01.01' />
+          <CustomText type='Content' text='2021.01.01' />
         </div>
       </div>
     </Slide>

--- a/src/components/Pages/MainPage.tsx
+++ b/src/components/Pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Button } from "@mui/material";
+import { BottomNavigation, Box, Button } from "@mui/material";
 import Header from "../Header/Header";
 import RegistComponent from "./RegistPage/RegistComponent";
 import PortfolioCreate from "./PortfolioPage/PortfolioCreate";
@@ -30,9 +30,9 @@ const MainPage = (props: Props) => {
   // console.log(searchParmas.get("accessToken"));
 
   return (
-    <Box className='h-full flex flex-col '>
+    <Box className='h-full flex flex-col mainpage'>
       <Header />
-      <div className='flex-1 relative flex'>
+      <div className='flex-1 relative flex overflow-y-scroll'>
         <RegistComponent />
         <PortfolioCreate />
         <PortfolioPage />
@@ -48,43 +48,46 @@ const MainPage = (props: Props) => {
         >
           <Button
             variant='contained'
-            onClick={() => dispatch(intoView("Regist"))}
+            onClick={() => dispatch(intoView({ view: "Regist" }))}
           >
             RegistPage
           </Button>
           <Button
             variant='contained'
-            onClick={() => dispatch(intoView("PortfolioCreate"))}
+            onClick={() => dispatch(intoView({ view: "PortfolioCreate" }))}
           >
             PortfolioCreatePage
           </Button>
           <Button
             variant='contained'
-            onClick={() => dispatch(intoView("Portfolio"))}
+            onClick={() => dispatch(intoView({ view: "Portfolio" }))}
           >
             PortfolioPage
           </Button>
           <Button
             variant='contained'
-            onClick={() => dispatch(intoView("Item"))}
+            onClick={() => dispatch(intoView({ view: "Item" }))}
           >
             ItemPage
           </Button>
           <Button
             variant='contained'
-            onClick={() => dispatch(intoView("ItemCreate"))}
+            onClick={() => dispatch(intoView({ view: "ItemCreate" }))}
           >
             ItemCreatePage
           </Button>
           <Button
             variant='contained'
-            onClick={() => dispatch(intoView("Planner"))}
+            onClick={() =>
+              dispatch(intoView({ view: "Planner", requestParam: "1" }))
+            }
           >
             PlannerPage
           </Button>
           <Button href={KAKAO_LOGIN_URL}>just-href</Button>
         </div>
       </div>
+      <BottomNavigation />
     </Box>
   );
 };

--- a/src/components/Pages/PlannerPage/PlannerPage.tsx
+++ b/src/components/Pages/PlannerPage/PlannerPage.tsx
@@ -1,0 +1,31 @@
+import { Button, Slide } from "@mui/material";
+import React from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "../../../store/store";
+import PortfolioHeader from "../PortfolioPage/subComponents/PortfolioHeader";
+import CustomText from "../../Modules/CustomText";
+import CustomTag from "../../Modules/CustomTag";
+import CustomTagBlock from "../../Modules/CustomTagBlock";
+import PlannerInfo from "./subComponent/PlannerInfo";
+import PlannerPortfolio from "./subComponent/PlannerPortfolio";
+
+type Props = {};
+
+const PlannerPage = (props: Props) => {
+  const view = useSelector((state: RootState) => state.view.currentView);
+  return (
+    <Slide
+      direction={`${view === "Planner" ? "right" : "left"}`}
+      in={view === "Planner"}
+      mountOnEnter
+      unmountOnExit
+    >
+      <div className='absolute w-full h-full px-4 flex flex-col gap-5'>
+        <PlannerInfo />
+        <PlannerPortfolio />
+      </div>
+    </Slide>
+  );
+};
+
+export default PlannerPage;

--- a/src/components/Pages/PlannerPage/subComponent/PlannerInfo.tsx
+++ b/src/components/Pages/PlannerPage/subComponent/PlannerInfo.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import CustomText from "../../../Modules/CustomText";
+import CustomTagBlock from "../../../Modules/CustomTagBlock";
+const mockTag = ["친절한", "답변이빠른", "꼼꼼한"];
+
+type Props = {};
+
+const PlannerInfo = (props: Props) => {
+  return (
+    <div>
+      <div className='flex flex-col items-center mt-4 gap-2'>
+        <img
+          src='https://images.pexels.com/photos/4491469/pexels-photo-4491469.jpeg'
+          className='w-[84px] h-[84px] rounded-full  object-cover'
+        />
+        <div className='flex flex-col items-center gap-0.5'>
+          <CustomText text='플래너' type='Title-large' />
+          <CustomText text='소속/직급/서울' type='Description' />
+        </div>
+        <CustomTagBlock spreadValues={mockTag} />
+      </div>
+    </div>
+  );
+};
+
+export default PlannerInfo;

--- a/src/components/Pages/PlannerPage/subComponent/PlannerPortfolio.tsx
+++ b/src/components/Pages/PlannerPage/subComponent/PlannerPortfolio.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import CustomText from "../../../Modules/CustomText";
+import { useDispatch } from "react-redux";
+import { intoView } from "../../../../store/viewSlice";
+
+type Props = {};
+const mockData = [
+  {
+    portfolioId: 1,
+    title: "선남선녀",
+    repImgUrl:
+      "https://images.pexels.com/photos/2788488/pexels-photo-2788488.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+  },
+  {
+    portfolioId: 4,
+    title: "선남선녀",
+    repImgUrl:
+      "https://images.pexels.com/photos/2814808/pexels-photo-2814808.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+  },
+  {
+    portfolioId: 5,
+    title: "선남선녀",
+    repImgUrl:
+      "https://images.pexels.com/photos/3342697/pexels-photo-3342697.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+  },
+  {
+    portfolioId: 6,
+    title: "생화 꽃다발 만원의행복 꽃다발💐 랜덤꽃 계절꽃다발",
+    repImgUrl:
+      "https://images.pexels.com/photos/1608590/pexels-photo-1608590.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+  },
+];
+
+const PlannerPortfolio = (props: Props) => {
+  const dispatch = useDispatch();
+  // make server axios get logic
+  const portfolioList = mockData.map((data) => (
+    <button
+      onClick={() =>
+        dispatch(
+          intoView({ view: "Portfolio", requestParam: data.portfolioId })
+        )
+      }
+      key={data.portfolioId}
+      className='h-56 flex flex-col gap-1.5'
+    >
+      <img
+        src={data.repImgUrl}
+        alt='Planner Portfolio Image'
+        className='w-full max-h-44 object-cover rounded-sm'
+      />
+      <CustomText text={data.title} type='Content-small' />
+    </button>
+  ));
+
+  return (
+    <div className='w-full h-full grid grid-cols-2 auto-rows-max gap-x-[6px] gap-y-6 items-center'>
+      {portfolioList}
+    </div>
+  );
+};
+
+export default PlannerPortfolio;

--- a/src/components/Pages/PortfolioPage/PortfolioPage.tsx
+++ b/src/components/Pages/PortfolioPage/PortfolioPage.tsx
@@ -26,7 +26,7 @@ const PortfolioPage = (props: Props) => {
         </div>
         <div className='mt-12'>
           <Button
-            onClick={() => dispatch(intoView("ItemCreate"))}
+            onClick={() => dispatch(intoView({ view: "ItemCreate" }))}
             sx={{ height: "38px", width: "100%" }}
             variant='outlined'
           >

--- a/src/components/Pages/PortfolioPage/subComponents/PortfolioItemCard.tsx
+++ b/src/components/Pages/PortfolioPage/subComponents/PortfolioItemCard.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import CustomText from "../../../Modules/CustomText";
+import { useDispatch } from "react-redux";
+import { intoView } from "../../../../store/viewSlice";
 
 type Props = {};
 interface itemAdjustStates {
@@ -23,12 +25,20 @@ type cardData = {
   date?: string;
 };
 const PortfolioItemCard = (props: Props) => {
+  const dispatch = useDispatch();
+
   const getItemCard = (mockData: cardData[]) => {
     return mockData.map((item, index) => {
       return (
-        <div className='flex flex-col gap-1.5' key={index}>
+        <div className='flex flex-col gap-1.5' key={index} onClick={() => {}}>
           <CustomText type='Title-base' text={item.categoryContent} />
-          <div className='relative rounded border shadow-md p-4' key={index}>
+          <div
+            onClick={() =>
+              dispatch(intoView({ view: "Item", requestParam: item.itemId }))
+            }
+            className='relative rounded border shadow-md p-4 hover:cursor-pointer'
+            key={index}
+          >
             <div>
               <div>{item?.date}</div>
               <div>{item.itemRecord}</div>

--- a/src/index.pcss
+++ b/src/index.pcss
@@ -4,7 +4,6 @@
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
-
 html,
 body {
   margin: 0;
@@ -12,6 +11,11 @@ body {
   width: 100%;
   display: flex;
   justify-content: center;
+  -ms-overflow-style: none;
+}
+
+::-webkit-scrollbar {
+  display: none;
 }
 #root {
   height: 100%;

--- a/src/store/viewSlice.tsx
+++ b/src/store/viewSlice.tsx
@@ -11,10 +11,19 @@ import type { RootState } from "./store";
  * }
  *
  */
+type Pagelst =
+  | "Regist"
+  | "LandingPage"
+  | "PortfolioCreate"
+  | "Portfolio"
+  | "Item"
+  | "ItemCreate"
+  | "Planner";
 
 interface viewState {
-  currentView: string;
-  viewStack: string[];
+  currentView: Pagelst;
+  viewStack: Pagelst[];
+  requestParam: string | number;
   page: number;
   prevPage: number;
 }
@@ -22,6 +31,7 @@ interface viewState {
 const initialState: viewState = {
   currentView: "LandingPage",
   viewStack: [],
+  requestParam: "",
   page: 0,
   prevPage: 0,
 };
@@ -48,10 +58,21 @@ export const viewSlice = createSlice({
         state.currentView = prevPage;
       }
     },
-    intoView: (state, action: PayloadAction<string>) => {
+    intoView: (
+      state,
+      action: PayloadAction<{ view: Pagelst; requestParam?: string | number }>
+    ) => {
+      console.log("REDUX", action.payload);
       state.viewStack.push(state.currentView);
-      state.currentView = action.payload;
+      state.currentView = action.payload.view;
+      state.requestParam = action.payload.requestParam ?? "";
     },
+    // i want to take 2 parameter in intoView function and second parameter is optional
+    // intoView: (state, action: PayloadAction<string, string>) => {
+    //   state.viewStack.push(state.currentView);
+    //   state.currentView = action.payload;
+    //   state.viewId = action.payload2;
+    // },
   },
 });
 


### PR DESCRIPTION
### 작업 개요
<!-- 작업 요약 내용을 적어주세요 -->
플래너 페이지 완료 및 전환 페이지간 전환기능 추가


### 작업 분류
<!-- 필수로 한 개 선택해주세요 -->
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<!-- 작업한 내용을 상세히 설명해주세요 -->
- 플래너 페이지에 들어가는 대략적인 요소들 추가 완료
- 리덕스 사용하여 아이템 - 포트폴리오 - 플래너 페이지 간 페이지 전환
- 페이지 전환 시 GET 요청 보내야하는 parameterID 전달
