### PR TITLE
[SO-264] fix : key값 customer로 변경 및 사진 업로드 개수 변경

### DIFF
--- a/src/components/Modules/InfoIndicator.tsx
+++ b/src/components/Modules/InfoIndicator.tsx
@@ -15,7 +15,7 @@ type Props = {
   type: "item" | "portfolio";
 };
 
-const plannerURL = SERVER_URL + "/api/v1/planner/";
+const plannerURL = SERVER_URL + "/api/v1/customer/";
 const portfolioURL = SERVER_URL + "/api/v1/portfolio/";
 const plannerLink = "/planner/";
 const portfolioLink = "/portfolio/";
@@ -76,7 +76,8 @@ const InfoIndicator = (props: Props) => {
         portfolioRes.data.data.id,
       ]);
     }
-    const plannerId = portfolioRes.data.data.plannerId;
+    const plannerId = portfolioRes.data.data.userId;
+  
     const plannerRes = await axios.get(plannerURL + plannerId, {
       headers: {
         Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
@@ -86,7 +87,7 @@ const InfoIndicator = (props: Props) => {
       setPlannerInfo([
         plannerRes.data.data.profileImageUrl,
         plannerRes.data.data.nickname,
-        plannerRes.data.data.plannerProfileId,
+        plannerRes.data.data.userId,
       ]);
     }
     setLoading(false);

--- a/src/components/Pages/CreatePage/ItemCreate.tsx
+++ b/src/components/Pages/CreatePage/ItemCreate.tsx
@@ -208,7 +208,7 @@ const ItemCreate = (props: Props) => {
                 <ItemCategories required />
                 <ImageUploader
                   title='image'
-                  maxCount={5}
+                  maxCount={10}
                   isImmediately={true}
                   required
                 />

--- a/src/components/Pages/PlannerPage/PlannerPage.tsx
+++ b/src/components/Pages/PlannerPage/PlannerPage.tsx
@@ -27,9 +27,10 @@ const PlannerPage = (props: Props) => {
   const navigate = useNavigate();
   const view = useSelector((state: RootState) => state.view.currentView);
   const plannerId = parseInt(useParams().Id ?? "0");
+
   const requestURL = props.mypage
-    ? `/api/v1/profile/planner`
-    : `/api/v1/planner/${plannerId}`;
+    ? `/api/v1/profile/customer`
+    : `/api/v1/customer/${plannerId}`;
   const { data, isLoading } = useQuery(
     ["plannerInfo", plannerId],
     () =>

--- a/src/components/Pages/PlannerPage/subComponent/PlannerInfo.tsx
+++ b/src/components/Pages/PlannerPage/subComponent/PlannerInfo.tsx
@@ -23,8 +23,8 @@ const PlannerInfo = (props: Props) => {
   const [imgURL, setImgURL] = useState("");
   const plannerId = parseInt(useParams().Id ?? "0");
   const requestURL = props.mypage
-    ? `/api/v1/profile/planner`
-    : `/api/v1/planner/${plannerId}`;
+    ? `/api/v1/profile/customer`
+    : `/api/v1/customer/${plannerId}`;
   const { data, isLoading } = useQuery(
     ["plannerInfo", plannerId],
     () =>

--- a/src/components/Pages/PortfolioPage/PortfolioPage.tsx
+++ b/src/components/Pages/PortfolioPage/PortfolioPage.tsx
@@ -32,7 +32,7 @@ type headerData = {
   region: string;
   isWriter: boolean;
   isLiked: boolean;
-  plannerId: number;
+  userId: number;
 };
 type portfolioData = {
   typeTag: "portfolio";
@@ -117,7 +117,7 @@ const PortfolioPage = (props: Props) => {
               {!isWriter && (
                 <div className='mt-12'>
                   <Button
-                    onClick={() => navigate(`/planner/${headerData.plannerId}`)}
+                    onClick={() => navigate(`/planner/${headerData.userId}`)}
                     sx={{ height: "38px", width: "100%", color: "#fff" }}
                     variant='contained'
                   >


### PR DESCRIPTION
### 작업 개요
- planner에서 customer로 타겟이 변경되면서 planner로 호출하던 url들을 customer로 변경
- customer api 호출 시 사용하는 path parameter 값 userId로 변경
- 사진 업로드 개수 10개로 수정
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->

### 생각해볼 문제
1. 지금은 customer로만 페이지가 연결되게 변경하였지만 만일 추후에 planner와 customer가 동시에 사이트에 들어오게 된다면 이 둘을 분리하는 작업이 필요할 듯 합니다.
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->